### PR TITLE
make 빌드에서 필요한 부분만 빌드하도록 간소화

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -547,6 +547,9 @@ update: .FORCE
 update_code: .FORCE
 	$(PYTHON) ./build_files/utils/make_update.py --no-libraries
 
+skp: .FORCE
+	$(PYTHON) ./make_skp.py
+
 format: .FORCE
 	PATH="../lib/${OS_NCASE}_${CPU}/llvm/bin/:../lib/${OS_NCASE}_centos7_${CPU}/llvm/bin/:../lib/${OS_NCASE}/llvm/bin/:$(PATH)" \
 	    $(PYTHON) source/tools/utils_maintenance/clang_format_paths.py $(PATHS)

--- a/build_files/windows/make_skp.cmd
+++ b/build_files/windows/make_skp.cmd
@@ -1,0 +1,13 @@
+if EXIST %PYTHON% (
+	goto detect_python_done
+)
+
+echo python not found in lib folder
+exit /b 1
+
+:detect_python_done
+
+REM Use -B to avoid writing __pycache__ in lib directory and causing update conflicts.
+%PYTHON% -B %BLENDER_DIR%\make_skp.py
+
+:EOF

--- a/build_files/windows/parse_arguments.cmd
+++ b/build_files/windows/parse_arguments.cmd
@@ -92,6 +92,8 @@ if NOT "%1" == "" (
 	) else if "%1" == "code_update" (
 		SET BUILD_UPDATE=1
 		set BUILD_UPDATE_ARGS="--no-libraries"
+	) else if "%1" == "skp" (
+	    SET BUILD_SKP=1
 	) else if "%1" == "ninja" (
 		SET BUILD_WITH_NINJA=1
 	) else if "%1" == "sccache" (

--- a/make.bat
+++ b/make.bat
@@ -69,6 +69,13 @@ if "%BUILD_UPDATE%" == "1" (
 	goto EOF
 )
 
+if "%BUILD_SKP%" == "1" (
+    call "%BLENDER_DIR%\build_files\windows\make_skp.cmd"
+    if errorlevel 1 goto EOF
+
+    goto EOF
+)
+
 call "%BLENDER_DIR%\build_files\windows\set_build_dir.cmd"
 
 :convenience_targets

--- a/make_skp.py
+++ b/make_skp.py
@@ -1,0 +1,30 @@
+import os
+import platform
+import shutil
+
+SOURCE = "./release/scripts/addons_acon3d/io_skp"
+DESTINATION = ""
+TARGET = "2.96/scripts/addons_acon3d/io_skp"
+
+
+def copy_scripts(src, dest):
+    shutil.copytree(src, dest, dirs_exist_ok=True)
+
+
+# Set destination path each OS
+if platform.system() == "Windows":
+    DESTINATION = "../build_windows_x64_vc17_Release/bin/Release/"
+    DESTINATION = os.path.join(DESTINATION, TARGET)
+elif platform.system() == "Darwin":
+    DESTINATION = "../build_darwin/bin/ABLER.app/Contents/Resources/"
+    DESTINATION = os.path.join(DESTINATION, TARGET)
+else:
+    print("Not supported")
+    exit(1)
+
+# Copy scripts
+try:
+    copy_scripts(SOURCE, DESTINATION)
+    print("Successfully copied scripts from addons_acon3d/io_skp")
+except Exception as e:
+    raise e

--- a/make_skp.py
+++ b/make_skp.py
@@ -4,7 +4,7 @@ import shutil
 
 SOURCE = "./release/scripts/addons_acon3d/io_skp"
 DESTINATION = ""
-TARGET = "2.96/scripts/addons_acon3d/io_skp"
+TARGET = "3.0/scripts/addons_acon3d/io_skp"
 
 
 def copy_scripts(src, dest):

--- a/make_skp.py
+++ b/make_skp.py
@@ -16,7 +16,7 @@ if platform.system() == "Windows":
     DESTINATION = "../build_windows_x64_vc17_Release/bin/Release/"
     DESTINATION = os.path.join(DESTINATION, TARGET)
 elif platform.system() == "Darwin":
-    DESTINATION = "../build_darwin/bin/ABLER.app/Contents/Resources/"
+    DESTINATION = "../build_darwin/bin/Blender.app/Contents/Resources/"
     DESTINATION = os.path.join(DESTINATION, TARGET)
 else:
     print("Not supported")


### PR DESCRIPTION
# 개요

`make` 빌드는 모든 파일을 새로 빌드하므로, 여기에서 필요한 부분만 빌드하도록 간소화

### 관련 문서

- [[ACON3D/blender] 명령어로 io_skp 빌드 #87](https://github.com/ACON3D/blender/pull/87)
- [Notion 태스크](https://www.notion.so/acon3d/make-skp-3eb1e528486b45f087ee0d879735b80d)


# 진행 작업

- 명령어 `make skp` 세팅 (Windows, MacOS)
- MacOS에서 `ABLER.app`을 실행하던 부분을 `Blender.app`으로 수정


# 결론

None.