### PR TITLE
백그라운드 실행할 때의 파일 경로 공백 처리

### DIFF
--- a/background.py
+++ b/background.py
@@ -4,7 +4,7 @@ import bpy
 
 argv = sys.argv
 argv = argv[argv.index("--") + 1:]  # get all args after "--"
-filename = argv[0]
+filename = " ".join(argv)
 name, ext = os.path.splitext(filename)
 
 


### PR DESCRIPTION
# 개요

백그라운드로 실행할 때, 파일 경로에 공백이 있으면 `sys.argv`에서 공백을 분리해서 가져오는 문제가 있음

### 관련 문서

- [Notion 태스크](https://www.notion.so/acon3d/c9ace03415fe456bb29335065d92d8d9)


# 진행 상황

- 파일 경로에 공백이 있으면 공백이 포함된 경로로 수정
- `background_recursive.py`에서 `background.py`로 `argv`를 전달할 때 공백으로 나눠지는 문제가 있어서 `argv`를 공백으로 `join` 해줌


# 결론

None.